### PR TITLE
Add optional basic auth support for scans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ IMAGE_NAME := vuln-scanner-kali
 CONTAINER_NAME := vuln-scanner-kali-run
 REPORT_DIR := $(CURDIR)/reports
 TARGET ?= http://127.0.0.1:8080
+BASIC_AUTH_USER ?=
+BASIC_AUTH_PASS ?=
 
 .PHONY: build run shell zap-baseline zap-full nikto nmap scan sqlmap scan-all clean
 
@@ -10,87 +12,105 @@ build:
 
 run:
 	mkdir -p $(REPORT_DIR)
-	docker run --rm -it \
-	  --name $(CONTAINER_NAME) \
-	  -e TARGET=$(TARGET) \
-	  -v $(REPORT_DIR):/zap/reports \
-	  $(IMAGE_NAME)
+        docker run --rm -it \
+          --name $(CONTAINER_NAME) \
+          -e TARGET=$(TARGET) \
+          -e BASIC_AUTH_USER="$(BASIC_AUTH_USER)" \
+          -e BASIC_AUTH_PASS="$(BASIC_AUTH_PASS)" \
+          -v $(REPORT_DIR):/zap/reports \
+          $(IMAGE_NAME)
 
 shell:
 	mkdir -p $(REPORT_DIR)
-	docker run --rm -it \
-	  --name $(CONTAINER_NAME) \
-	  -e TARGET=$(TARGET) \
-	  -v $(REPORT_DIR):/zap/reports \
-	  $(IMAGE_NAME) bash
+        docker run --rm -it \
+          --name $(CONTAINER_NAME) \
+          -e TARGET=$(TARGET) \
+          -e BASIC_AUTH_USER="$(BASIC_AUTH_USER)" \
+          -e BASIC_AUTH_PASS="$(BASIC_AUTH_PASS)" \
+          -v $(REPORT_DIR):/zap/reports \
+          $(IMAGE_NAME) bash
 
 # Запуск ZAP baseline напрямую (если скрипты скачаны)
 zap-baseline:
 	mkdir -p $(REPORT_DIR)
-	docker run --rm -it \
-	  -e TARGET=$(TARGET) \
-	  -v $(REPORT_DIR):/zap/reports \
-	  $(IMAGE_NAME) \
-	  bash -lc "python3 /opt/zap-scripts/zap-baseline.py -t $(TARGET) -r /zap/reports/zap_baseline.html -d || true"
+        docker run --rm -it \
+          -e TARGET=$(TARGET) \
+          -e BASIC_AUTH_USER="$(BASIC_AUTH_USER)" \
+          -e BASIC_AUTH_PASS="$(BASIC_AUTH_PASS)" \
+          -v $(REPORT_DIR):/zap/reports \
+          $(IMAGE_NAME) \
+          bash -lc "python3 /opt/zap-scripts/zap-baseline.py -t $(TARGET) -r /zap/reports/zap_baseline.html -d || true"
 
 zap-full:
 	mkdir -p $(REPORT_DIR)
-	docker run --rm -it \
-	  -e TARGET=$(TARGET) \
-	  -v $(REPORT_DIR):/zap/reports \
-	  $(IMAGE_NAME) \
-	  bash -lc "python3 /opt/zap-scripts/zap-full-scan.py -t $(TARGET) -r /zap/reports/zap_full.html -d || true"
+        docker run --rm -it \
+          -e TARGET=$(TARGET) \
+          -e BASIC_AUTH_USER="$(BASIC_AUTH_USER)" \
+          -e BASIC_AUTH_PASS="$(BASIC_AUTH_PASS)" \
+          -v $(REPORT_DIR):/zap/reports \
+          $(IMAGE_NAME) \
+          bash -lc "python3 /opt/zap-scripts/zap-full-scan.py -t $(TARGET) -r /zap/reports/zap_full.html -d || true"
 
 nikto:
 	mkdir -p $(REPORT_DIR)
-	docker run --rm -it \
-	  -e TARGET=$(TARGET) \
-	  -v $(REPORT_DIR):/zap/reports \
-	  $(IMAGE_NAME) \
-	  nikto -h $(TARGET) -o /zap/reports/nikto.html -Format html
+        docker run --rm -it \
+          -e TARGET=$(TARGET) \
+          -e BASIC_AUTH_USER="$(BASIC_AUTH_USER)" \
+          -e BASIC_AUTH_PASS="$(BASIC_AUTH_PASS)" \
+          -v $(REPORT_DIR):/zap/reports \
+          $(IMAGE_NAME) \
+          nikto -h $(TARGET) -o /zap/reports/nikto.html -Format html
 
 nmap:
 	mkdir -p $(REPORT_DIR)
-	docker run --rm -it --cap-add=NET_RAW --cap-add=NET_ADMIN \
-	  -e TARGET=$(TARGET) \
-	  -v $(REPORT_DIR):/zap/reports \
-	  $(IMAGE_NAME) \
-	  bash -lc "nmap -sS -sV -Pn --top-ports 1000 -oA /zap/reports/nmap $(shell echo $(TARGET) | sed -E 's#^https?://##' | sed -E 's#/.*$$//')"
+        docker run --rm -it --cap-add=NET_RAW --cap-add=NET_ADMIN \
+          -e TARGET=$(TARGET) \
+          -e BASIC_AUTH_USER="$(BASIC_AUTH_USER)" \
+          -e BASIC_AUTH_PASS="$(BASIC_AUTH_PASS)" \
+          -v $(REPORT_DIR):/zap/reports \
+          $(IMAGE_NAME) \
+          bash -lc "nmap -sS -sV -Pn --top-ports 1000 -oA /zap/reports/nmap $(shell echo $(TARGET) | sed -E 's#^https?://##' | sed -E 's#/.*$$//')"
 
 sqlmap:
 	@mkdir -p $(REPORT_DIR)
 	@echo "[*] Running sqlmap in container..."
-	docker run --rm -it \
-	  --name $(CONTAINER_NAME)-sqlmap \
-	  -e TARGET=$(TARGET) \
-	  -e SQLMAP=true \
-	  -e SQLMAP_OPTS="$(SQLMAP_OPTS)" \
-	  -e SQLMAP_DATA="$(SQLMAP_DATA)" \
-	  -v $(REPORT_DIR):/zap/reports \
-	  $(IMAGE_NAME) \
-	  /usr/local/bin/scan.sh
+        docker run --rm -it \
+          --name $(CONTAINER_NAME)-sqlmap \
+          -e TARGET=$(TARGET) \
+          -e SQLMAP=true \
+          -e SQLMAP_OPTS="$(SQLMAP_OPTS)" \
+          -e SQLMAP_DATA="$(SQLMAP_DATA)" \
+          -e BASIC_AUTH_USER="$(BASIC_AUTH_USER)" \
+          -e BASIC_AUTH_PASS="$(BASIC_AUTH_PASS)" \
+          -v $(REPORT_DIR):/zap/reports \
+          $(IMAGE_NAME) \
+          /usr/local/bin/scan.sh
 
 scan: build
 	mkdir -p $(REPORT_DIR)
-	docker run --rm -it \
-	  --name $(CONTAINER_NAME) \
-	  -e TARGET=$(TARGET) \
-	  -v $(REPORT_DIR):/zap/reports \
-	  $(IMAGE_NAME) \
-	  /usr/local/bin/scan.sh
+        docker run --rm -it \
+          --name $(CONTAINER_NAME) \
+          -e TARGET=$(TARGET) \
+          -e BASIC_AUTH_USER="$(BASIC_AUTH_USER)" \
+          -e BASIC_AUTH_PASS="$(BASIC_AUTH_PASS)" \
+          -v $(REPORT_DIR):/zap/reports \
+          $(IMAGE_NAME) \
+          /usr/local/bin/scan.sh
 
 # Включая sqlmap
 scan-all: build
 	mkdir -p $(REPORT_DIR)
-	docker run --rm -it \
-	  --name $(CONTAINER_NAME) \
-	  -e TARGET=$(TARGET) \
-	  -e SQLMAP=true \
-	  -e SQLMAP_OPTS="$(SQLMAP_OPTS)" \
-	  -e SQLMAP_DATA="$(SQLMAP_DATA)" \
-	  -v $(REPORT_DIR):/zap/reports \
-	  $(IMAGE_NAME) \
-	  /usr/local/bin/scan.sh
+        docker run --rm -it \
+          --name $(CONTAINER_NAME) \
+          -e TARGET=$(TARGET) \
+          -e SQLMAP=true \
+          -e SQLMAP_OPTS="$(SQLMAP_OPTS)" \
+          -e SQLMAP_DATA="$(SQLMAP_DATA)" \
+          -e BASIC_AUTH_USER="$(BASIC_AUTH_USER)" \
+          -e BASIC_AUTH_PASS="$(BASIC_AUTH_PASS)" \
+          -v $(REPORT_DIR):/zap/reports \
+          $(IMAGE_NAME) \
+          /usr/local/bin/scan.sh
 
 clean:
 	rm -rf $(REPORT_DIR)/* || true

--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@
 
    Отчёты появятся в `./reports/`.
 
+   Если целевой сервер защищён базовой авторизацией (например, nginx с `auth_basic`),
+   передайте логин и пароль через переменные окружения `BASIC_AUTH_USER` и `BASIC_AUTH_PASS`:
+
+   ```bash
+   make scan TARGET=http://your-target.example.com \
+     BASIC_AUTH_USER=tester BASIC_AUTH_PASS=secret
+   ```
+
+   Указанные значения будут автоматически использованы в ZAP, Nikto и sqlmap.
+   При наличии специальных символов в пароле не забудьте URL-кодировать их.
+
 ## Примеры команд
 
 * Только ZAP baseline:

--- a/scan.sh
+++ b/scan.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 # Параметры (можно задавать через env или через make)
 TARGET="${TARGET:-}"
+BASIC_AUTH_USER="${BASIC_AUTH_USER:-}"
+BASIC_AUTH_PASS="${BASIC_AUTH_PASS:-}"
 REPORT_DIR="${REPORT_DIR:-/zap/reports}"
 ZAP_SCRIPTS_DIR="${ZAP_SCRIPTS_DIR:-/opt/zap-scripts}"
 ZAP_CMD="${ZAP_CMD:-/usr/bin/zaproxy}"
@@ -17,9 +19,34 @@ fi
 
 mkdir -p "$REPORT_DIR"
 
+# Формируем URL с учётом Basic Auth, если логин и пароль переданы.
+TARGET_WITH_AUTH="$TARGET"
+if [ -n "$BASIC_AUTH_USER" ] && [ -n "$BASIC_AUTH_PASS" ]; then
+  # Встраиваем user:pass прямо в URL (https://user:pass@host)
+  case "$TARGET" in
+    http://*)
+      TARGET_WITH_AUTH="http://${BASIC_AUTH_USER}:${BASIC_AUTH_PASS}@${TARGET#http://}"
+      ;;
+    https://*)
+      TARGET_WITH_AUTH="https://${BASIC_AUTH_USER}:${BASIC_AUTH_PASS}@${TARGET#https://}"
+      ;;
+    *)
+      echo "[!] BASIC_AUTH_* задан, но TARGET не содержит схему http(s). Использую TARGET как есть."
+      ;;
+  esac
+fi
+
+AUTH_CREDENTIALS=""
+if [ -n "$BASIC_AUTH_USER" ] && [ -n "$BASIC_AUTH_PASS" ]; then
+  AUTH_CREDENTIALS="$BASIC_AUTH_USER:$BASIC_AUTH_PASS"
+fi
+
 timestamp() { date +%Y%m%d_%H%M%S; }
 
 echo "[*] Target: $TARGET"
+if [ -n "$AUTH_CREDENTIALS" ]; then
+  echo "[*] Basic auth credentials supplied for target"
+fi
 echo "[*] Reports folder: $REPORT_DIR"
 
 # ---- 1) ZAP baseline (headless) ----
@@ -29,7 +56,7 @@ if [ -x "$ZAP_SCRIPTS_DIR/zap-baseline.py" ]; then
   # Запускаем ZAP в фоновом режиме (daemon), затем запускаем скрипт.
   $ZAP_CMD -daemon -host 127.0.0.1 -port 8090 -config api.disablekey=true >/dev/null 2>&1 || true
   sleep 3
-  python3 "$ZAP_SCRIPTS_DIR/zap-baseline.py" -t "$TARGET" -r "$BASELINE_HTML" -d || echo "[!] ZAP baseline exited non-zero"
+  python3 "$ZAP_SCRIPTS_DIR/zap-baseline.py" -t "$TARGET_WITH_AUTH" -r "$BASELINE_HTML" -d || echo "[!] ZAP baseline exited non-zero"
   # Попытаемся корректно остановить ZAP
   pkill -f zaproxy || true
 else
@@ -42,7 +69,7 @@ if [ -x "$ZAP_SCRIPTS_DIR/zap-full-scan.py" ]; then
   echo "[*] Running ZAP full-scan script (this may take long)..."
   $ZAP_CMD -daemon -host 127.0.0.1 -port 8090 -config api.disablekey=true >/dev/null 2>&1 || true
   sleep 5
-  python3 "$ZAP_SCRIPTS_DIR/zap-full-scan.py" -t "$TARGET" -r "$FULL_HTML" -d || echo "[!] ZAP full scan exited non-zero"
+  python3 "$ZAP_SCRIPTS_DIR/zap-full-scan.py" -t "$TARGET_WITH_AUTH" -r "$FULL_HTML" -d || echo "[!] ZAP full scan exited non-zero"
   pkill -f zaproxy || true
 else
   echo "[!] zap-full-scan.py not found in $ZAP_SCRIPTS_DIR — skipping ZAP full scan."
@@ -51,7 +78,11 @@ fi
 # ---- 3) Nikto ----
 NIKTO_HTML="$REPORT_DIR/nikto_$(timestamp).html"
 echo "[*] Running Nikto..."
-nikto -h "$TARGET" -o "$NIKTO_HTML" -Format html || echo "[!] Nikto exited non-zero"
+if [ -n "$AUTH_CREDENTIALS" ]; then
+  nikto -h "$TARGET" -o "$NIKTO_HTML" -Format html -id "$AUTH_CREDENTIALS" || echo "[!] Nikto exited non-zero"
+else
+  nikto -h "$TARGET" -o "$NIKTO_HTML" -Format html || echo "[!] Nikto exited non-zero"
+fi
 
 # ---- 4) Nmap ----
 echo "[*] Running Nmap (top ports)..."
@@ -67,10 +98,14 @@ if [ "$SQLMAP" = "true" ]; then
   echo "[*] Running sqlmap..."
   SQLMAP_OUTDIR="$REPORT_DIR/sqlmap_$(timestamp)"
   mkdir -p "$SQLMAP_OUTDIR"
+  SQLMAP_AUTH_OPTS=()
+  if [ -n "$AUTH_CREDENTIALS" ]; then
+    SQLMAP_AUTH_OPTS+=(--auth-type=Basic "--auth-cred=$AUTH_CREDENTIALS")
+  fi
   if [ -n "$SQLMAP_DATA" ]; then
-    sqlmap -u "$TARGET" --data "$SQLMAP_DATA" --batch --output-dir="$SQLMAP_OUTDIR" $SQLMAP_OPTS || echo "[!] sqlmap exited non-zero"
+    sqlmap -u "$TARGET" --data "$SQLMAP_DATA" --batch --output-dir="$SQLMAP_OUTDIR" ${SQLMAP_AUTH_OPTS[@]} $SQLMAP_OPTS || echo "[!] sqlmap exited non-zero"
   else
-    sqlmap -u "$TARGET" --batch --output-dir="$SQLMAP_OUTDIR" $SQLMAP_OPTS || echo "[!] sqlmap exited non-zero"
+    sqlmap -u "$TARGET" --batch --output-dir="$SQLMAP_OUTDIR" ${SQLMAP_AUTH_OPTS[@]} $SQLMAP_OPTS || echo "[!] sqlmap exited non-zero"
   fi
   echo "[*] sqlmap output in: $SQLMAP_OUTDIR"
 else


### PR DESCRIPTION
## Summary
- pass optional BASIC_AUTH_USER and BASIC_AUTH_PASS environment variables through Docker wrappers
- update scan pipeline to reuse basic auth credentials for ZAP, Nikto, and sqlmap
- document how to run scans against nginx basic-auth protected targets

## Testing
- bash -n scan.sh

------
https://chatgpt.com/codex/tasks/task_e_68e4140e0e5c8323a80456dc493c31b3